### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Signals [![Build Status](https://secure.travis-ci.org/stevepeak/signals.png)](http://travis-ci.org/stevepeak/signals) [![Version](https://pypip.in/v/signals/badge.png)](https://github.com/stevepeak/signals)
+# Signals [![Build Status](https://secure.travis-ci.org/stevepeak/signals.png)](http://travis-ci.org/stevepeak/signals) [![Version](https://img.shields.io/pypi/v/signals.svg)](https://github.com/stevepeak/signals)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20signals))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `signals`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.